### PR TITLE
Remove some spring transitive dependencies

### DIFF
--- a/apis-authorization-server/pom.xml
+++ b/apis-authorization-server/pom.xml
@@ -40,10 +40,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -62,22 +64,27 @@
     <dependency>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-jpa</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -86,20 +93,24 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
+      <scope>provided</scope>
     </dependency>
     <!-- needed for spring's @Configuration -->
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.surfnet.coin</groupId>
       <artifactId>coin-test</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
To be able to use apis-authorization-server in projects without Spring (my case: Guice + AppEngine, no Spring) some dependencies should not be enforced. AFAICS, this is the bare minimum that can be done in this aspect. It should not be breaking anything.

On the other hand, almost all the cases where commons-lang classes are being used could be done with Guava equivalent classes instead, saving also an extra dependency.
