### PR TITLE
Upgrade spring dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
     <hsqldb.version>2.2.8</hsqldb.version>
     <junit.version>4.10</junit.version>
     <tomcat-jdbc.version>7.0.29</tomcat-jdbc.version>
-    <spring.version>3.2.1.RELEASE</spring.version>
-    <spring-security.version>3.2.1.RELEASE</spring-security.version>
+    <spring.version>3.2.7.RELEASE</spring.version>
+    <spring-security.version>3.2.7.RELEASE</spring-security.version>
     <openjpa.version>2.2.0</openjpa.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-io.version>2.0.1</commons-io.version>


### PR DESCRIPTION
Upgrade spring dependencies to fix build errors, I chose 3.2.7-RELEASE since maven resolved spring-orm to that release and needed a compatible version of org.springframework.beans.factory.annotation.InjectionMetadata
