### PR TITLE
fix: append state param after imlicit grant response url is formatted

### DIFF
--- a/apis-authorization-server/src/main/java/org/surfnet/oaaas/resource/TokenResource.java
+++ b/apis-authorization-server/src/main/java/org/surfnet/oaaas/resource/TokenResource.java
@@ -323,8 +323,9 @@ public class TokenResource {
 
   private Response sendImplicitGrantResponse(AuthorizationRequest authReq, AccessToken accessToken) {
     String uri = authReq.getRedirectUri();
-    String fragment = String.format("access_token=%s&token_type=bearer&expires_in=%s&scope=%s"
-        + appendStateParameter(authReq), accessToken.getToken(), accessToken.getExpiresIn(), StringUtils.join(authReq.getGrantedScopes(), ','));
+    String fragment = String.format("access_token=%s&token_type=bearer&expires_in=%s&scope=%s", 
+      accessToken.getToken(), accessToken.getExpiresIn(), StringUtils.join(authReq.getGrantedScopes(), ',')) + 
+      appendStateParameter(authReq);
     if (authReq.getClient().isIncludePrincipal()) {
       fragment += String.format("&principal=%s", authReq.getPrincipal().getDisplayName()) ;
     }


### PR DESCRIPTION
This prevent String.format to interpret %-signs in the state parameter.
For example if state includes a / it will be encoded as %2F and String.format
will try to interpret %2F as a substitution token and fails.