### PR TITLE
Minor fixes - NPE checks and additional client validations

### DIFF
--- a/apis-authorization-server/src/main/java/org/surfnet/oaaas/auth/AuthenticationFilter.java
+++ b/apis-authorization-server/src/main/java/org/surfnet/oaaas/auth/AuthenticationFilter.java
@@ -39,137 +39,139 @@ import java.util.UUID;
 @Named
 public class AuthenticationFilter implements Filter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AuthenticationFilter.class);
+	private static final Logger LOG = LoggerFactory.getLogger(AuthenticationFilter.class);
 
-  private AbstractAuthenticator authenticator;
+	private AbstractAuthenticator authenticator;
 
-  @Inject
-  private AuthorizationRequestRepository authorizationRequestRepository;
+	@Inject
+	private AuthorizationRequestRepository authorizationRequestRepository;
 
-  @Inject
-  private OAuth2Validator oAuth2Validator;
+	@Inject
+	private OAuth2Validator oAuth2Validator;
 
-  @Override
-  public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
-    HttpServletRequest request = (HttpServletRequest) req;
-    HttpServletResponse response = (HttpServletResponse) res;
+	@Override
+	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+		HttpServletRequest request = (HttpServletRequest) req;
+		HttpServletResponse response = (HttpServletResponse) res;
 
-    /*
-     * Create an authorizationRequest from the request parameters.
-     * This can be either a valid or an invalid request, which will be determined by the oAuth2Validator.
-     */
-    AuthorizationRequest authorizationRequest = extractAuthorizationRequest(request);
-    final ValidationResponse validationResponse = oAuth2Validator.validate(authorizationRequest);
+		/*
+		 * Create an authorizationRequest from the request parameters. This can
+		 * be either a valid or an invalid request, which will be determined by
+		 * the oAuth2Validator.
+		 */
+		AuthorizationRequest authorizationRequest = extractAuthorizationRequest(request);
+		final ValidationResponse validationResponse = oAuth2Validator.validate(authorizationRequest);
 
-    if (authenticator.canCommence(request)) {
-      /*
-      * Ok, the authenticator wants to have control again (because he stepped
-      * out)
-      */
-      authenticator.doFilter(request, response, chain);
-    } else if (validationResponse.valid()) {
-      // Request contains correct parameters to be a real OAuth2 request.
-      handleInitialRequest(authorizationRequest, request);
-      authenticator.doFilter(request, response, chain);
-    } else {
-      // not an initial request but authentication module cannot handle it either
-      sendError(response, authorizationRequest, validationResponse);
-    }
-  }
+		if (authenticator.canCommence(request)) {
+			/*
+			 * Ok, the authenticator wants to have control again (because he
+			 * stepped out)
+			 */
+			authenticator.doFilter(request, response, chain);
+		} else if (validationResponse.valid()) {
+			// Request contains correct parameters to be a real OAuth2 request.
+			handleInitialRequest(authorizationRequest, request);
+			authenticator.doFilter(request, response, chain);
+		} else {
+			// not an initial request but authentication module cannot handle it
+			// either
+			sendError(response, authorizationRequest, validationResponse);
+		}
+	}
 
-  protected AuthorizationRequest extractAuthorizationRequest(HttpServletRequest request) {
-    String responseType = request.getParameter("response_type");
-    String clientId = request.getParameter("client_id");
-    String redirectUri = request.getParameter("redirect_uri");
+	protected AuthorizationRequest extractAuthorizationRequest(HttpServletRequest request) {
+		String responseType = request.getParameter("response_type");
+		String clientId = request.getParameter("client_id");
+		String redirectUri = request.getParameter("redirect_uri");
 
-    List<String> requestedScopes = null;
-    if (StringUtils.isNotBlank(request.getParameter("scope"))) {
-      requestedScopes = Arrays.asList(request.getParameter("scope").split(","));
-    }
+		List<String> requestedScopes = null;
+		if (StringUtils.isNotBlank(request.getParameter("scope"))) {
+			requestedScopes = Arrays.asList(request.getParameter("scope").split(","));
+		}
 
-    String state = request.getParameter("state");
-    String authState = getAuthStateValue();
+		String state = request.getParameter("state");
+		String authState = getAuthStateValue();
 
-    return new AuthorizationRequest(responseType, clientId, redirectUri, requestedScopes, state, authState);
-  }
+		return new AuthorizationRequest(responseType, clientId, redirectUri, requestedScopes, state, authState);
+	}
 
-  private boolean handleInitialRequest(AuthorizationRequest authReq, HttpServletRequest request) throws
-      ServletException {
+	private boolean handleInitialRequest(AuthorizationRequest authReq, HttpServletRequest request) throws ServletException {
 
-      try {
-        authorizationRequestRepository.save(authReq);
-      } catch (Exception e) {
-        LOG.error("while saving authorization request", e);
-        throw new ServletException("Cannot save authorization request");
-      }
+		try {
+			authorizationRequestRepository.save(authReq);
+		} catch (Exception e) {
+			LOG.error("while saving authorization request", e);
+			throw new ServletException("Cannot save authorization request");
+		}
 
-      request.setAttribute(AbstractAuthenticator.AUTH_STATE, authReq.getAuthState());
-      request.setAttribute(AbstractAuthenticator.RETURN_URI, request.getRequestURI());
-      return true;
-  }
+		request.setAttribute(AbstractAuthenticator.AUTH_STATE, authReq.getAuthState());
+		request.setAttribute(AbstractAuthenticator.RETURN_URI, request.getRequestURI());
+		return true;
+	}
 
-  protected String getAuthStateValue() {
-    return UUID.randomUUID().toString();
-  }
+	protected String getAuthStateValue() {
+		return UUID.randomUUID().toString();
+	}
 
-  private void sendError(HttpServletResponse response, AuthorizationRequest authReq, ValidationResponse validate)
-      throws IOException {
-    LOG.info("Will send error response for authorization request '{}', validation result: {}", authReq, validate);
-    String redirectUri = authReq.getRedirectUri();
-    String state = authReq.getState();
-    if (isValidUri(redirectUri)) {
-      redirectUri = redirectUri.concat(redirectUri.contains("?") ? "&" : "?");
-      redirectUri = redirectUri
-              .concat("error=").concat(validate.getValue())
-              .concat("&error_description=").concat(validate.getDescription())
-              .concat(StringUtils.isBlank(state) ? "" : "&state=".concat(URLEncoder.encode(state, "UTF-8")));
-      LOG.info("Sending error response, a redirect to: {}", redirectUri);
-      response.sendRedirect(redirectUri);
-    } else {
-      LOG.info("Sending error response 'bad request': {}", validate.getDescription());
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, validate.getDescription());
-    }
-  }
+	private void sendError(HttpServletResponse response, AuthorizationRequest authReq, ValidationResponse validate) throws IOException {
+		LOG.info("Will send error response for authorization request '{}', validation result: {}", authReq, validate);
+		String redirectUri = authReq.getRedirectUri();
+		String state = authReq.getState();
+		if (isValidUri(redirectUri)) {
+			redirectUri = redirectUri.concat(redirectUri.contains("?") ? "&" : "?");
+			redirectUri = redirectUri.concat("error=").concat(validate.getValue()).concat("&error_description=").concat(validate.getDescription())
+					.concat(StringUtils.isBlank(state) ? "" : "&state=".concat(URLEncoder.encode(state, "UTF-8")));
+			LOG.info("Sending error response, a redirect to: {}", redirectUri);
+			response.sendRedirect(redirectUri);
+		} else {
+			LOG.info("Sending error response 'bad request': {}", validate.getDescription());
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, validate.getDescription());
+		}
+	}
 
-  @Override
-  public void destroy() {
-  }
+	@Override
+	public void destroy() {
+	}
 
-  @Override
-  public void init(FilterConfig filterConfig) throws ServletException {
-  }
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
 
-  public void setAuthenticator(AbstractAuthenticator authenticator) {
-    this.authenticator = authenticator;
-  }
+	public void setAuthenticator(AbstractAuthenticator authenticator) {
+		this.authenticator = authenticator;
+	}
 
-  public static boolean isValidUri(String redirectUri) {
-    try {
-      URI uri = new URI(redirectUri);
-      if (uri.getScheme() != null) {
-        return true;
-      } else {
-        return false;
-      }
-    } catch (URISyntaxException e) {
-      return false;
-    }
-  }
+	public static boolean isValidUri(String redirectUri) {
+		if (StringUtils.isEmpty(redirectUri)) {
+			return false;
+		}
+		
+		try {
+			URI uri = new URI(redirectUri);
+			if (uri.getScheme() != null) {
+				return true;
+			} else {
+				return false;
+			}
+		} catch (URISyntaxException e) {
+			return false;
+		}
+	}
 
-  /**
-   * @param authorizationRequestRepository
-   *          the authorizationRequestRepository to set
-   */
-  public void setAuthorizationRequestRepository(AuthorizationRequestRepository authorizationRequestRepository) {
-    this.authorizationRequestRepository = authorizationRequestRepository;
-  }
+	/**
+	 * @param authorizationRequestRepository
+	 *            the authorizationRequestRepository to set
+	 */
+	public void setAuthorizationRequestRepository(AuthorizationRequestRepository authorizationRequestRepository) {
+		this.authorizationRequestRepository = authorizationRequestRepository;
+	}
 
-  /**
-   * @param oAuth2Validator
-   *          the oAuth2Validator to set
-   */
-  public void setOAuth2Validator(OAuth2Validator oAuth2Validator) {
-    this.oAuth2Validator = oAuth2Validator;
-  }
+	/**
+	 * @param oAuth2Validator
+	 *            the oAuth2Validator to set
+	 */
+	public void setOAuth2Validator(OAuth2Validator oAuth2Validator) {
+		this.oAuth2Validator = oAuth2Validator;
+	}
 
 }

--- a/apis-authorization-server/src/main/java/org/surfnet/oaaas/auth/OAuth2Validator.java
+++ b/apis-authorization-server/src/main/java/org/surfnet/oaaas/auth/OAuth2Validator.java
@@ -90,7 +90,7 @@ public interface OAuth2Validator {
 
     REDIRECT_URI_NOT_URI("invalid_request", "The redirect_uri is not a valid URI"),
 
-    REDIRECT_URI_DIFFERENT("invaid_request","The redirect_uri does not match the initial authorization request"),
+    REDIRECT_URI_DIFFERENT("invalid_request","The redirect_uri does not match the initial authorization request"),
     
     SCOPE_NOT_VALID("invalid_scope", "The requested scope is invalid, unknown, malformed, " +
         "or exceeds the scope granted by the resource owner."),

--- a/apis-authorization-server/src/main/java/org/surfnet/oaaas/auth/OAuth2ValidatorImpl.java
+++ b/apis-authorization-server/src/main/java/org/surfnet/oaaas/auth/OAuth2ValidatorImpl.java
@@ -212,6 +212,8 @@ public class OAuth2ValidatorImpl implements OAuth2Validator {
       // Use the request parameters to obtain the client
       client = getClient(accessTokenRequest.getClientId(), accessTokenRequest.getClientSecret(), 
           UNKNOWN_CLIENT_ID);
+    } else {
+    	throw new ValidationResponseException(UNKNOWN_CLIENT_ID);
     }
 
     // Record the associated client

--- a/apis-authorization-server/src/main/java/org/surfnet/oaaas/resource/TokenResource.java
+++ b/apis-authorization-server/src/main/java/org/surfnet/oaaas/resource/TokenResource.java
@@ -18,7 +18,32 @@
  */
 package org.surfnet.oaaas.resource;
 
-import com.sun.jersey.api.client.ClientResponse.Status;
+import static org.surfnet.oaaas.auth.OAuth2Validator.BEARER;
+import static org.surfnet.oaaas.auth.OAuth2Validator.GRANT_TYPE_AUTHORIZATION_CODE;
+import static org.surfnet.oaaas.auth.OAuth2Validator.GRANT_TYPE_CLIENT_CREDENTIALS;
+import static org.surfnet.oaaas.auth.OAuth2Validator.GRANT_TYPE_PASSWORD;
+import static org.surfnet.oaaas.auth.OAuth2Validator.GRANT_TYPE_REFRESH_TOKEN;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -28,357 +53,338 @@ import org.surfnet.oaaas.auth.AbstractAuthenticator;
 import org.surfnet.oaaas.auth.AbstractUserConsentHandler;
 import org.surfnet.oaaas.auth.AuthenticationFilter;
 import org.surfnet.oaaas.auth.OAuth2Validator;
+import org.surfnet.oaaas.auth.OAuth2Validator.ValidationResponse;
 import org.surfnet.oaaas.auth.ResourceOwnerAuthenticator;
-import org.surfnet.oaaas.auth.OAuth2Validator.*;
 import org.surfnet.oaaas.auth.ValidationResponseException;
 import org.surfnet.oaaas.auth.principal.AuthenticatedPrincipal;
 import org.surfnet.oaaas.auth.principal.BasicAuthCredentials;
-import org.surfnet.oaaas.model.*;
+import org.surfnet.oaaas.model.AccessToken;
+import org.surfnet.oaaas.model.AccessTokenRequest;
+import org.surfnet.oaaas.model.AccessTokenResponse;
+import org.surfnet.oaaas.model.AuthorizationRequest;
+import org.surfnet.oaaas.model.Client;
+import org.surfnet.oaaas.model.ErrorResponse;
 import org.surfnet.oaaas.repository.AccessTokenRepository;
 import org.surfnet.oaaas.repository.AuthorizationRequestRepository;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.Arrays;
-import java.util.UUID;
-
-import static org.surfnet.oaaas.auth.OAuth2Validator.*;
+import com.sun.jersey.api.client.ClientResponse.Status;
 
 /**
  * Resource for handling all calls related to tokens. It adheres to <a
  * href="http://tools.ietf.org/html/draft-ietf-oauth-v2"> the OAuth spec</a>.
- *
+ * 
  */
 @Named
 @Path("/")
 public class TokenResource {
 
-  public static final String BASIC_REALM = "Basic realm=\"OAuth2 Secure\"";
+	public static final String BASIC_REALM = "Basic realm=\"OAuth2 Secure\"";
 
-  public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
+	public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
 
-  @Inject
-  private AuthorizationRequestRepository authorizationRequestRepository;
+	@Inject
+	private AuthorizationRequestRepository authorizationRequestRepository;
 
-  @Inject
-  private AccessTokenRepository accessTokenRepository;
+	@Inject
+	private AccessTokenRepository accessTokenRepository;
 
-  @Inject
-  private OAuth2Validator oAuth2Validator;
-  
-  @Inject
-  private ResourceOwnerAuthenticator resourceOwnerAuthenticator;
+	@Inject
+	private OAuth2Validator oAuth2Validator;
 
-  private static final Logger LOG = LoggerFactory.getLogger(TokenResource.class);
+	@Inject
+	private ResourceOwnerAuthenticator resourceOwnerAuthenticator;
 
-  /**
-   * The "authorization endpoint" as described in <a
-   * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-3.1">Section 3.1</a> of
-   * the OAuth spec.  This provides the optional GET support.  Access to this endpoint requires
-   * authentication of the requestor (the resource owner) which must be accomplished via a
-   * configured {@link AuthenticationFilter}.
-   * 
-   * @param request
-   *          the {@link HttpServletRequest}
-   * @return the response
-   */
-  @GET
-  @Path("/authorize")
-  public Response authorizeCallbackGet(@Context HttpServletRequest request) {
-    return authorizeCallback(request);
-  }
+	private static final Logger LOG = LoggerFactory.getLogger(TokenResource.class);
 
-  /**
-   * Entry point for the authorize call which needs to return an authorization
-   * code or (implicit grant) an access token.    Access to this endpoint requires
-   * authentication of the requestor (the resource owner) which must be accomplished via a
-   * configured {@link AuthenticationFilter}.
-   *
-   * @param request
-   *          the {@link HttpServletRequest}
-   * @return Response the response
-   */
-  @POST
-  @Produces(MediaType.TEXT_HTML)
-  @Path("/authorize")
-  public Response authorizeCallback(@Context HttpServletRequest request) {
-    return doProcess(request);
-  }
+	/**
+	 * The "authorization endpoint" as described in <a
+	 * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-3.1"
+	 * >Section 3.1</a> of the OAuth spec. This provides the optional GET
+	 * support. Access to this endpoint requires authentication of the requestor
+	 * (the resource owner) which must be accomplished via a configured
+	 * {@link AuthenticationFilter}.
+	 * 
+	 * @param request
+	 *            the {@link HttpServletRequest}
+	 * @return the response
+	 */
+	@GET
+	@Path("/authorize")
+	public Response authorizeCallbackGet(@Context HttpServletRequest request) {
+		return authorizeCallback(request);
+	}
 
-  /**
-   * Called after the user has given consent
-   *
-   * @param request
-   *          the {@link HttpServletRequest}
-   * @return Response the response
-   */
-  @POST
-  @Produces(MediaType.TEXT_HTML)
-  @Path("/consent")
-  public Response consentCallback(@Context HttpServletRequest request) {
-    return doProcess(request);
-  }
+	/**
+	 * Entry point for the authorize call which needs to return an authorization
+	 * code or (implicit grant) an access token. Access to this endpoint
+	 * requires authentication of the requestor (the resource owner) which must
+	 * be accomplished via a configured {@link AuthenticationFilter}.
+	 * 
+	 * @param request
+	 *            the {@link HttpServletRequest}
+	 * @return Response the response
+	 */
+	@POST
+	@Produces(MediaType.TEXT_HTML)
+	@Path("/authorize")
+	public Response authorizeCallback(@Context HttpServletRequest request) {
+		return doProcess(request);
+	}
 
-  private Response doProcess(HttpServletRequest request) {
-    AuthorizationRequest authReq = findAuthorizationRequest(request);
-    if (authReq == null) {
-      return serverError("Not a valid AbstractAuthenticator.AUTH_STATE on the Request");
-    }
-    processScopes(authReq, request);
-    if (authReq.getResponseType().equals(OAuth2Validator.IMPLICIT_GRANT_RESPONSE_TYPE)) {
-      AccessToken token = createAccessToken(authReq, true);
-      return sendImplicitGrantResponse(authReq, token);
-    } else {
-      return sendAuthorizationCodeResponse(authReq);
-    }
-  }
+	/**
+	 * Called after the user has given consent
+	 * 
+	 * @param request
+	 *            the {@link HttpServletRequest}
+	 * @return Response the response
+	 */
+	@POST
+	@Produces(MediaType.TEXT_HTML)
+	@Path("/consent")
+	public Response consentCallback(@Context HttpServletRequest request) {
+		return doProcess(request);
+	}
 
-  /*
-   * In the user consent filter the scopes are (possible) set on the Request
-   */
-  private void processScopes(AuthorizationRequest authReq, HttpServletRequest request) {
-    if (authReq.getClient().isSkipConsent()) {
-      // return the scopes in the authentication request since the requested scopes are stored in the
-      // authorizationRequest.
-      authReq.setGrantedScopes(authReq.getRequestedScopes());
-    } else {
-      String[] scopes = (String[]) request.getAttribute(AbstractUserConsentHandler.GRANTED_SCOPES);
-      if (!ArrayUtils.isEmpty(scopes)) {
-        authReq.setGrantedScopes(Arrays.asList(scopes));
-      } else {
-        authReq.setGrantedScopes(null);
-      }
-    }
-  }
+	private Response doProcess(HttpServletRequest request) {
+		AuthorizationRequest authReq = findAuthorizationRequest(request);
+		if (authReq == null) {
+			return serverError("Not a valid AbstractAuthenticator.AUTH_STATE on the Request");
+		}
+		processScopes(authReq, request);
+		if (authReq.getResponseType().equals(OAuth2Validator.IMPLICIT_GRANT_RESPONSE_TYPE)) {
+			AccessToken token = createAccessToken(authReq, true);
+			return sendImplicitGrantResponse(authReq, token);
+		} else {
+			return sendAuthorizationCodeResponse(authReq);
+		}
+	}
 
-  private AccessToken createAccessToken(AuthorizationRequest request, boolean isImplicitGrant) {
-    Client client = request.getClient();
-    long expireDuration = client.getExpireDuration();
-    long expires = (expireDuration == 0L ? 0L : (System.currentTimeMillis() + (1000 * expireDuration)));
-    String refreshToken = (client.isUseRefreshTokens() && !isImplicitGrant) ? getTokenValue(true) : null;
-    AuthenticatedPrincipal principal = request.getPrincipal();
-    AccessToken token = new AccessToken(getTokenValue(false), principal, client, expires, request.getGrantedScopes(), refreshToken);
-    return accessTokenRepository.save(token);
-  }
+	/*
+	 * In the user consent filter the scopes are (possible) set on the Request
+	 */
+	private void processScopes(AuthorizationRequest authReq, HttpServletRequest request) {
+		if (authReq.getClient().isSkipConsent()) {
+			// return the scopes in the authentication request since the
+			// requested scopes are stored in the
+			// authorizationRequest.
+			authReq.setGrantedScopes(authReq.getRequestedScopes());
+		} else {
+			String[] scopes = (String[]) request.getAttribute(AbstractUserConsentHandler.GRANTED_SCOPES);
+			if (!ArrayUtils.isEmpty(scopes)) {
+				authReq.setGrantedScopes(Arrays.asList(scopes));
+			} else {
+				authReq.setGrantedScopes(null);
+			}
+		}
+	}
 
-  private AuthorizationRequest findAuthorizationRequest(HttpServletRequest request) {
-    String authState = (String) request.getAttribute(AbstractAuthenticator.AUTH_STATE);
-    return authorizationRequestRepository.findByAuthState(authState);
-  }
+	private AccessToken createAccessToken(AuthorizationRequest request, boolean isImplicitGrant) {
+		Client client = request.getClient();
+		long expireDuration = client.getExpireDuration();
+		long expires = (expireDuration == 0L ? 0L : (System.currentTimeMillis() + (1000 * expireDuration)));
+		String refreshToken = (client.isUseRefreshTokens() && !isImplicitGrant) ? getTokenValue(true) : null;
+		AuthenticatedPrincipal principal = request.getPrincipal();
+		AccessToken token = new AccessToken(getTokenValue(false), principal, client, expires, request.getGrantedScopes(), refreshToken);
+		return accessTokenRepository.save(token);
+	}
 
-  /**
-   * The "token endpoint" as described in <a
-   * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-3.2">Section 3.2</a> of
-   * the OAuth spec.
-   * 
-   * @param authorization the HTTP Basic auth header.
-   * @param formParameters the request parameters
-   * @return the response
-   */
-  @POST
-  @Path("/token")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Consumes("application/x-www-form-urlencoded")
-  public Response token(@HeaderParam("Authorization") String authorization, 
-          final MultivaluedMap<String, String> formParameters) {
-    // Convert incoming parameters into internal form and validate them
-    AccessTokenRequest accessTokenRequest = 
-            AccessTokenRequest.fromMultiValuedFormParameters(formParameters);
-    BasicAuthCredentials credentials = 
-        BasicAuthCredentials.createCredentialsFromHeader(authorization);
+	private AuthorizationRequest findAuthorizationRequest(HttpServletRequest request) {
+		String authState = (String) request.getAttribute(AbstractAuthenticator.AUTH_STATE);
+		return authorizationRequestRepository.findByAuthState(authState);
+	}
 
-    ValidationResponse vr = oAuth2Validator.validate(accessTokenRequest, credentials);
-    if (!vr.valid()) {
-      return sendErrorResponse(vr);
-    }
-    
-    // The request looks valid, attempt to process
-    String grantType = accessTokenRequest.getGrantType();
-    AuthorizationRequest request;
-    try {
-      if (GRANT_TYPE_AUTHORIZATION_CODE.equals(grantType)) {
-        request = authorizationCodeToken(accessTokenRequest);
-      } else if (GRANT_TYPE_REFRESH_TOKEN.equals(grantType)) {
-        request = refreshTokenToken(accessTokenRequest);
-      } else if (GRANT_TYPE_CLIENT_CREDENTIALS.equals(grantType)) {
-        request = clientCredentialToken(accessTokenRequest);
-      } else if (GRANT_TYPE_PASSWORD.equals(grantType)) {
-        request = passwordToken(accessTokenRequest);
-      } else {
-        return sendErrorResponse(ValidationResponse.UNSUPPORTED_GRANT_TYPE);
-      }
-    } catch (ValidationResponseException e) {
-      return sendErrorResponse(e.v);
-    }
-    AccessToken token = createAccessToken(request, false);
+	/**
+	 * The "token endpoint" as described in <a
+	 * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-3.2"
+	 * >Section 3.2</a> of the OAuth spec.
+	 * 
+	 * @param authorization
+	 *            the HTTP Basic auth header.
+	 * @param formParameters
+	 *            the request parameters
+	 * @return the response
+	 */
+	@POST
+	@Path("/token")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes("application/x-www-form-urlencoded")
+	public Response token(@HeaderParam("Authorization") String authorization, final MultivaluedMap<String, String> formParameters) {
+		// Convert incoming parameters into internal form and validate them
+		AccessTokenRequest accessTokenRequest = AccessTokenRequest.fromMultiValuedFormParameters(formParameters);
+		BasicAuthCredentials credentials = BasicAuthCredentials.createCredentialsFromHeader(authorization);
 
-    AccessTokenResponse response = new AccessTokenResponse(token.getToken(), BEARER, token.getExpiresIn(), token.getRefreshToken(), StringUtils.join(token.getScopes(), ' '));
+		ValidationResponse vr = oAuth2Validator.validate(accessTokenRequest, credentials);
+		if (!vr.valid()) {
+			return sendErrorResponse(vr);
+		}
 
-    return Response
-            .ok()
-            .entity(response)
-            .cacheControl(cacheControlNoStore())
-            .header("Pragma", "no-cache")
-            .build();
+		// The request looks valid, attempt to process
+		String grantType = accessTokenRequest.getGrantType();
+		AuthorizationRequest request;
+		try {
+			if (GRANT_TYPE_AUTHORIZATION_CODE.equals(grantType)) {
+				request = authorizationCodeToken(accessTokenRequest);
+			} else if (GRANT_TYPE_REFRESH_TOKEN.equals(grantType)) {
+				request = refreshTokenToken(accessTokenRequest);
+			} else if (GRANT_TYPE_CLIENT_CREDENTIALS.equals(grantType)) {
+				request = clientCredentialToken(accessTokenRequest);
+			} else if (GRANT_TYPE_PASSWORD.equals(grantType)) {
+				request = passwordToken(accessTokenRequest);
+			} else {
+				return sendErrorResponse(ValidationResponse.UNSUPPORTED_GRANT_TYPE);
+			}
+		} catch (ValidationResponseException e) {
+			return sendErrorResponse(e.v);
+		}
+		AccessToken token = createAccessToken(request, false);
 
-  }
+		AccessTokenResponse response = new AccessTokenResponse(token.getToken(), BEARER, token.getExpiresIn(), token.getRefreshToken(), StringUtils.join(token.getScopes(), ' '));
 
-  private CacheControl cacheControlNoStore() {
-    CacheControl cacheControl = new CacheControl();
-    cacheControl.setNoStore(true);
-    return cacheControl;
-  }
+		return Response.ok().entity(response).cacheControl(cacheControlNoStore()).header("Pragma", "no-cache").build();
 
-  private AuthorizationRequest authorizationCodeToken(AccessTokenRequest accessTokenRequest) {
-    AuthorizationRequest authReq = authorizationRequestRepository.findByAuthorizationCode(accessTokenRequest.getCode());
-    if (authReq == null) {
-      throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_AUTHORIZATION_CODE);
-    }
-    String uri = accessTokenRequest.getRedirectUri();
-    if (!authReq.getRedirectUri().equalsIgnoreCase(uri)) {
-      throw new ValidationResponseException(ValidationResponse.REDIRECT_URI_DIFFERENT);
-    }
-    authorizationRequestRepository.delete(authReq);
-    return authReq;
-  }
+	}
 
-  private AuthorizationRequest refreshTokenToken(AccessTokenRequest accessTokenRequest) {
-    AccessToken accessToken = accessTokenRepository.findByRefreshToken(accessTokenRequest.getRefreshToken());
-    if (accessToken == null) {
-      throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_REFRESH_TOKEN);
-    }
-    AuthorizationRequest request = new AuthorizationRequest();
-    request.setClient(accessToken.getClient());
-    request.setPrincipal(accessToken.getPrincipal());
-    request.setGrantedScopes(accessToken.getScopes());
-    accessTokenRepository.delete(accessToken);
-    return request;
+	private CacheControl cacheControlNoStore() {
+		CacheControl cacheControl = new CacheControl();
+		cacheControl.setNoStore(true);
+		return cacheControl;
+	}
 
-  }
-  
-  private AuthorizationRequest clientCredentialToken(AccessTokenRequest accessTokenRequest) {
-    AuthorizationRequest request =  new AuthorizationRequest();
-    request.setClient(accessTokenRequest.getClient());
-    // We have to construct a AuthenticatedPrincipal on-the-fly as there is only key-secret authentication
-    request.setPrincipal(new AuthenticatedPrincipal(request.getClient().getClientId()));
-    // Get scopes (either from request or the client's default set)
-    request.setGrantedScopes(accessTokenRequest.getScopeList());
-    return request;
-  }
-  
-  private AuthorizationRequest passwordToken(AccessTokenRequest accessTokenRequest) {
-    // Authenticate the resource owner
-    AuthenticatedPrincipal principal = 
-        resourceOwnerAuthenticator.authenticate(accessTokenRequest.getUsername(), 
-            accessTokenRequest.getPassword());
-    if (principal == null) {
-      throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_PASSWORD);
-    }
-    
-    AuthorizationRequest request = new AuthorizationRequest();
-    request.setClient(accessTokenRequest.getClient());
-    request.setPrincipal(principal);
-    request.setGrantedScopes(accessTokenRequest.getScopeList());
-    return request;
-  }
+	private AuthorizationRequest authorizationCodeToken(AccessTokenRequest accessTokenRequest) {
+		AuthorizationRequest authReq = authorizationRequestRepository.findByAuthorizationCode(accessTokenRequest.getCode());
+		if (authReq == null) {
+			throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_AUTHORIZATION_CODE);
+		}
+		String uri = accessTokenRequest.getRedirectUri();
+		if (!authReq.getRedirectUri().equalsIgnoreCase(uri)) {
+			throw new ValidationResponseException(ValidationResponse.REDIRECT_URI_DIFFERENT);
+		}
+		if (!authReq.getClient().getClientId().equals(accessTokenRequest.getClient().getClientId())) {
+			throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_AUTHORIZATION_CODE);
+		}
+		authorizationRequestRepository.delete(authReq);
+		return authReq;
+	}
 
+	private AuthorizationRequest refreshTokenToken(AccessTokenRequest accessTokenRequest) {
+		AccessToken accessToken = accessTokenRepository.findByRefreshToken(accessTokenRequest.getRefreshToken());
+		if (accessToken == null) {
+			throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_REFRESH_TOKEN);
+		}
+		if (!accessToken.getClient().getClientId().equals(accessTokenRequest.getClient().getClientId())) {
+			throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_REFRESH_TOKEN);
+		}
+		AuthorizationRequest request = new AuthorizationRequest();
+		request.setClient(accessToken.getClient());
+		request.setPrincipal(accessToken.getPrincipal());
+		request.setGrantedScopes(accessToken.getScopes());
+		accessTokenRepository.delete(accessToken);
+		return request;
 
-  private Response sendAuthorizationCodeResponse(AuthorizationRequest authReq) {
-    String uri = authReq.getRedirectUri();
-    String authorizationCode = getAuthorizationCodeValue();
-    authReq.setAuthorizationCode(authorizationCode);
-    authorizationRequestRepository.save(authReq);
-    uri = uri + appendQueryMark(uri) + "code=" + authorizationCode + appendStateParameter(authReq);
-    return Response
-            .seeOther(UriBuilder.fromUri(uri).build())
-            .cacheControl(cacheControlNoStore())
-            .header("Pragma", "no-cache")
-            .build();
-  }
+	}
 
-  protected String getTokenValue(boolean isRefreshToken) {
-    return UUID.randomUUID().toString();
-  }
+	private AuthorizationRequest clientCredentialToken(AccessTokenRequest accessTokenRequest) {
+		AuthorizationRequest request = new AuthorizationRequest();
+		request.setClient(accessTokenRequest.getClient());
+		// We have to construct a AuthenticatedPrincipal on-the-fly as there is
+		// only key-secret authentication
+		request.setPrincipal(new AuthenticatedPrincipal(request.getClient().getClientId()));
+		// Get scopes (either from request or the client's default set)
+		request.setGrantedScopes(accessTokenRequest.getScopeList());
+		return request;
+	}
 
-  protected String getAuthorizationCodeValue() {
-    return getTokenValue(false);
-  }
+	private AuthorizationRequest passwordToken(AccessTokenRequest accessTokenRequest) {
+		// Authenticate the resource owner
+		AuthenticatedPrincipal principal = resourceOwnerAuthenticator.authenticate(accessTokenRequest.getUsername(), accessTokenRequest.getPassword());
+		if (principal == null) {
+			throw new ValidationResponseException(ValidationResponse.INVALID_GRANT_PASSWORD);
+		}
 
-  private Response sendErrorResponse(String error, String description, Status status) {
-    if (status == Status.UNAUTHORIZED) {
-      return Response.status(Status.UNAUTHORIZED).header(WWW_AUTHENTICATE, BASIC_REALM).build();
-    }
-    return Response.status(status).entity(new ErrorResponse(error, description)).build();
-  }
+		AuthorizationRequest request = new AuthorizationRequest();
+		request.setClient(accessTokenRequest.getClient());
+		request.setPrincipal(principal);
+		request.setGrantedScopes(accessTokenRequest.getScopeList());
+		return request;
+	}
 
-  private Response sendErrorResponse(ValidationResponse response) {
-    return sendErrorResponse(response.getValue(), response.getDescription(), response.getStatus());
-  }
+	private Response sendAuthorizationCodeResponse(AuthorizationRequest authReq) {
+		String uri = authReq.getRedirectUri();
+		String authorizationCode = getAuthorizationCodeValue();
+		authReq.setAuthorizationCode(authorizationCode);
+		authorizationRequestRepository.save(authReq);
+		uri = uri + appendQueryMark(uri) + "code=" + authorizationCode + appendStateParameter(authReq);
+		return Response.seeOther(UriBuilder.fromUri(uri).build()).cacheControl(cacheControlNoStore()).header("Pragma", "no-cache").build();
+	}
 
-  private Response sendImplicitGrantResponse(AuthorizationRequest authReq, AccessToken accessToken) {
-    String uri = authReq.getRedirectUri();
-    String fragment = String.format("access_token=%s&token_type=bearer&expires_in=%s&scope=%s", 
-      accessToken.getToken(), accessToken.getExpiresIn(), StringUtils.join(authReq.getGrantedScopes(), ',')) + 
-      appendStateParameter(authReq);
-    if (authReq.getClient().isIncludePrincipal()) {
-      fragment += String.format("&principal=%s", authReq.getPrincipal().getDisplayName()) ;
-    }
-    return Response
-            .seeOther(UriBuilder.fromUri(uri)
-            .fragment(fragment).build())
-            .cacheControl(cacheControlNoStore())
-            .header("Pragma", "no-cache")
-            .build();
+	protected String getTokenValue(boolean isRefreshToken) {
+		return UUID.randomUUID().toString();
+	}
 
+	protected String getAuthorizationCodeValue() {
+		return getTokenValue(false);
+	}
 
-  }
+	private Response sendErrorResponse(String error, String description, Status status) {
+		return Response.status(status).entity(new ErrorResponse(error, description)).build();
+	}
 
-  private String appendQueryMark(String uri) {
-    return uri.contains("?") ? "&" : "?";
-  }
+	private Response sendErrorResponse(ValidationResponse response) {
+		return sendErrorResponse(response.getValue(), response.getDescription(), response.getStatus());
+	}
 
-  private String appendStateParameter(AuthorizationRequest authReq) {
-    String state = authReq.getState();
-    try {
-      return StringUtils.isBlank(state) ? "" : "&state=".concat(URLEncoder.encode(state, "UTF-8"));
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
+	private Response sendImplicitGrantResponse(AuthorizationRequest authReq, AccessToken accessToken) {
+		String uri = authReq.getRedirectUri();
+		String fragment = String.format("access_token=%s&token_type=bearer&expires_in=%s&scope=%s", accessToken.getToken(), accessToken.getExpiresIn(),
+				StringUtils.join(authReq.getGrantedScopes(), ','))
+				+ appendStateParameter(authReq);
+		if (authReq.getClient().isIncludePrincipal()) {
+			fragment += String.format("&principal=%s", authReq.getPrincipal().getDisplayName());
+		}
+		return Response.seeOther(UriBuilder.fromUri(uri).fragment(fragment).build()).cacheControl(cacheControlNoStore()).header("Pragma", "no-cache").build();
 
-  private Response serverError(String msg) {
-    LOG.warn(msg);
-    return Response.serverError().build();
-  }
+	}
 
-  /**
-   * @param authorizationRequestRepository
-   *          the authorizationRequestRepository to set
-   */
-  public void setAuthorizationRequestRepository(AuthorizationRequestRepository authorizationRequestRepository) {
-    this.authorizationRequestRepository = authorizationRequestRepository;
-  }
+	private String appendQueryMark(String uri) {
+		return uri.contains("?") ? "&" : "?";
+	}
 
-  /**
-   * @param accessTokenRepository
-   *          the accessTokenRepository to set
-   */
-  public void setAccessTokenRepository(AccessTokenRepository accessTokenRepository) {
-    this.accessTokenRepository = accessTokenRepository;
-  }
+	private String appendStateParameter(AuthorizationRequest authReq) {
+		String state = authReq.getState();
+		try {
+			return StringUtils.isBlank(state) ? "" : "&state=".concat(URLEncoder.encode(state, "UTF-8"));
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-  /**
-   * @param oAuth2Validator
-   *          the oAuth2Validator to set
-   */
-  public void setoAuth2Validator(OAuth2Validator oAuth2Validator) {
-    this.oAuth2Validator = oAuth2Validator;
-  }
+	private Response serverError(String msg) {
+		LOG.warn(msg);
+		return Response.serverError().build();
+	}
+
+	/**
+	 * @param authorizationRequestRepository
+	 *            the authorizationRequestRepository to set
+	 */
+	public void setAuthorizationRequestRepository(AuthorizationRequestRepository authorizationRequestRepository) {
+		this.authorizationRequestRepository = authorizationRequestRepository;
+	}
+
+	/**
+	 * @param accessTokenRepository
+	 *            the accessTokenRepository to set
+	 */
+	public void setAccessTokenRepository(AccessTokenRepository accessTokenRepository) {
+		this.accessTokenRepository = accessTokenRepository;
+	}
+
+	/**
+	 * @param oAuth2Validator
+	 *            the oAuth2Validator to set
+	 */
+	public void setoAuth2Validator(OAuth2Validator oAuth2Validator) {
+		this.oAuth2Validator = oAuth2Validator;
+	}
 
 }


### PR DESCRIPTION
AuthenticationFilter : Added check to see if the redirectURI is absent
OAuthValidator : Fixed a typo
OAuthValidatorImpl : Handling the scenario where the access token request contains a blank client id
TokenResource : Authorization Code Grant flow does not verify that the authorization code was granted to the same client which is making the request for token now. Fixed this.Also put in the same check while reissuing a token with a refresh token