### PR TITLE
Change request protocol for proxying Jetty

### DIFF
--- a/apis-authorization-server-war/pom.xml
+++ b/apis-authorization-server-war/pom.xml
@@ -203,9 +203,11 @@
                 <extraClasspath>${basedir}/src/test/resources/</extraClasspath>
               </webAppConfig>
               <connectors>
-                <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
+                <!--connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector"-->
+                <connector implementation="org.surfnet.oaaas.jetty.SelectChannelConnectorHttps">
                   <port>${servlet.port}</port>
                   <maxIdleTime>60000</maxIdleTime>
+                  <forwarded>true</forwarded>
                 </connector>
               </connectors>
               <daemon>true</daemon>
@@ -230,6 +232,13 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <dependency>
+                <groupId>nl.surfnet.apis</groupId>
+                <artifactId>jetty-connector</artifactId>
+                <version>1.3.6-SNAPSHOT</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -261,6 +270,11 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <dependencies>
+          <dependency>
+            <groupId>nl.surfnet.apis</groupId>
+            <artifactId>jetty-connector</artifactId>
+            <version>1.3.6-SNAPSHOT</version>
+          </dependency>
           <dependency>
             <groupId>org.surfnet.coin</groupId>
             <artifactId>mujina-idp</artifactId>
@@ -297,7 +311,8 @@
             <extraClasspath>${basedir}/src/test/resources/</extraClasspath>
           </webAppConfig>
           <connectors>
-            <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
+            <!--connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector"-->
+            <connector implementation="org.surfnet.oaaas.jetty.SelectChannelConnectorHttps">
               <port>${servlet.port}</port>
               <host>0.0.0.0</host>
             </connector>

--- a/jetty-connector/.gitignore
+++ b/jetty-connector/.gitignore
@@ -1,6 +1,0 @@
-.classpath
-.project
-.settings
-.idea
-*.iml
-target

--- a/jetty-connector/.gitignore
+++ b/jetty-connector/.gitignore
@@ -1,0 +1,6 @@
+.classpath
+.project
+.settings
+.idea
+*.iml
+target

--- a/jetty-connector/README.md
+++ b/jetty-connector/README.md
@@ -1,0 +1,9 @@
+Example Client App 
+======
+The Example Client App is a very simple Spring web application that is developed for demo purposes. With the client app you can see what the typical flow is for real clients of your Resource Server. The prerequisites for seeing the client app in action are:
+
+- The Authorization Server up and running
+- The Example Resource Server up and running
+
+See the documentation in the [README.md](https://github.com/OpenConextApps/apis/blob/master/README.md) in the root project for detailed instructions. 
+

--- a/jetty-connector/README.md
+++ b/jetty-connector/README.md
@@ -1,9 +1,11 @@
-Example Client App 
+Jetty Connector for proxied configuration
 ======
-The Example Client App is a very simple Spring web application that is developed for demo purposes. With the client app you can see what the typical flow is for real clients of your Resource Server. The prerequisites for seeing the client app in action are:
+This project contains an extension plugin for Jetty that permits to permit a proper Apache (or Nginx) proxying.
+This extension permits to implement the configuration described here:
+```
+   https                 http
+ --------->   Apache   -------> Jetty
+```
 
-- The Authorization Server up and running
-- The Example Resource Server up and running
-
-See the documentation in the [README.md](https://github.com/OpenConextApps/apis/blob/master/README.md) in the root project for detailed instructions. 
-
+To permit this workflow the request schema is retrieved from the `X-Forwarded-Proto` HTTP header.
+This is the standard behavior of Jetty 9, this extension makes it available also in Jetty 8.

--- a/jetty-connector/pom.xml
+++ b/jetty-connector/pom.xml
@@ -1,0 +1,31 @@
+<!-- Copyright 2012 SURFnet bv, The Netherlands Licensed under the Apache
+  License, Version 2.0 (the "License"); you may not use this file except in
+  compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <relativePath>../pom.xml</relativePath>
+    <groupId>nl.surfnet.apis</groupId>
+    <artifactId>apis-parent</artifactId>
+    <version>1.3.6-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jetty-connector</artifactId>
+  <packaging>jar</packaging>
+  <name>Connector to customize schema for Jetty 8</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>jetty-maven-plugin</artifactId>
+      <version>${jetty-maven-plugin.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-connector/pom.xml
+++ b/jetty-connector/pom.xml
@@ -26,6 +26,14 @@
       <artifactId>jetty-maven-plugin</artifactId>
       <version>${jetty-maven-plugin.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
+++ b/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
@@ -1,0 +1,26 @@
+package org.surfnet.oaaas.jetty;
+
+import java.io.IOException;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+public class SelectChannelConnectorHttps extends SelectChannelConnector {
+
+	public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
+
+	public void customize(EndPoint endpoint, Request request) throws IOException {
+
+		String forwardedProtocol = request.getHeader(X_FORWARDED_PROTO);
+		if (forwardedProtocol != null) {
+			if (forwardedProtocol.indexOf("https") != 0) {
+				request.setScheme("https");
+			}
+		}
+
+		super.customize(endpoint, request);
+	}
+
+}
+

--- a/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
+++ b/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
@@ -1,5 +1,6 @@
 package org.surfnet.oaaas.jetty;
 
+import java.util.Enumeration;
 import java.io.IOException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
@@ -10,11 +11,22 @@ public class SelectChannelConnectorHttps extends SelectChannelConnector {
 
 	public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
 
+	private String getHeaderCaseInsensitive(Request request, String headerName) {
+		Enumeration<String> headerNames = (Enumeration<String>) request.getHeaderNames();
+		while (headerNames.hasMoreElements()){
+			String curHeaderName = (String) headerNames.nextElement();
+			if (curHeaderName.toLowerCase().equals(headerName)) {
+				return request.getHeader(curHeaderName);
+			}
+		}
+		return null;
+	}
+
 	public void customize(EndPoint endpoint, Request request) throws IOException {
 
-		String forwardedProtocol = request.getHeader(X_FORWARDED_PROTO);
+		String forwardedProtocol = getHeaderCaseInsensitive(request, X_FORWARDED_PROTO);
 		if (forwardedProtocol != null) {
-			if (forwardedProtocol.indexOf("https") != 0) {
+			if (forwardedProtocol.indexOf("https") >= 0) {
 				request.setScheme("https");
 			}
 		}

--- a/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
+++ b/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.io.EndPoint;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 /**
  * {@link SelectChannelConnector} that sets the request schema according to the

--- a/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
+++ b/jetty-connector/src/main/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttps.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.surfnet.oaaas.jetty;
 
 import java.util.Enumeration;
@@ -7,9 +25,13 @@ import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
+/**
+ * {@link SelectChannelConnector} that sets the request schema according to the
+ * value eventually specified in the HTTP header name "X-ForwardedProto.
+ */
 public class SelectChannelConnectorHttps extends SelectChannelConnector {
 
-	public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
+	private static final String X_FORWARDED_PROTO = "x-forwarded-proto";
 
 	private String getHeaderCaseInsensitive(Request request, String headerName) {
 		Enumeration<String> headerNames = (Enumeration<String>) request.getHeaderNames();
@@ -22,6 +44,7 @@ public class SelectChannelConnectorHttps extends SelectChannelConnector {
 		return null;
 	}
 
+	@Override
 	public void customize(EndPoint endpoint, Request request) throws IOException {
 
 		String forwardedProtocol = getHeaderCaseInsensitive(request, X_FORWARDED_PROTO);

--- a/jetty-connector/src/test/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttpsTest.java
+++ b/jetty-connector/src/test/java/org/surfnet/oaaas/jetty/SelectChannelConnectorHttpsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.surfnet.oaaas.jetty;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Vector;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.io.EndPoint;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * {@link Test} that verifies the new Connector handles correctly the request schema depending on
+ * X-Forwarded-Proto HTTP haeder.
+ * 
+ */
+public class SelectChannelConnectorHttpsTest {
+
+	private static final String HTTP_SCHEME = "http";
+	private static final String HTTPS_SCHEME = "https";
+	
+	private static final String XFORWARDED_PROTO = "X-Forwarded-Proto";
+
+	@Test
+	public void testSchemaIsChangedAccordingToXForwardedProto() throws IOException {
+		Request baseRequest = new Request();
+		final Request request = Mockito.spy(baseRequest);
+		EndPoint endPoint = Mockito.mock(EndPoint.class);
+
+		Vector<String> headers = new Vector<String>();
+		headers.add(XFORWARDED_PROTO);
+		Mockito.doReturn(headers.elements()).when(request).getHeaderNames();
+		Mockito.doReturn(HTTPS_SCHEME).when(request).getHeader(XFORWARDED_PROTO);
+
+		SelectChannelConnectorHttps connector = new SelectChannelConnectorHttps();
+		connector.customize(endPoint, request);
+
+		assertEquals(HTTPS_SCHEME, request.getScheme());
+	}
+
+	@Test
+	public void testSchemaIsNotChangedForNoXForwardedProto() throws IOException {
+		Request baseRequest = new Request();
+		final Request request = Mockito.spy(baseRequest);
+		EndPoint endPoint = Mockito.mock(EndPoint.class);
+
+		Vector<String> headers = new Vector<String>();
+		Mockito.doReturn(headers.elements()).when(request).getHeaderNames();
+
+		SelectChannelConnectorHttps connector = new SelectChannelConnectorHttps();
+		connector.customize(endPoint, request);
+
+		assertEquals(HTTP_SCHEME, request.getScheme());
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <module>apis-example-client-app</module>
     <module>apis-openconext-mock-war</module>
     <module>apis-authorization-server-dist</module>
+    <module>jetty-connector</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
Hi,
in my configuration I wanted to have apache (or nginx) to proxy the Jetty server.
My configuration was like that:
```
   https                 http
 --------->   Apache   -------> Jetty
```

As suggested by this link: https://wiki.eclipse.org/Jetty/Howto/Configure_mod_proxy the solution could be that of extending the `SelectChannelConnector` to set the proper schema.
The schema is retrieved from the `X-Forwarded-Proto` HTTP header to keep the mechanism forward compatible with Jetty 9.