### PR TITLE
Adds capability for HTTPS connection for Authorization Server

### DIFF
--- a/apis-authorization-server-war/pom.xml
+++ b/apis-authorization-server-war/pom.xml
@@ -159,6 +159,11 @@
           <version>3.3.1</version>
       </dependency>
 
+    <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>jetty-ssl</artifactId>
+      <version>7.0.0.pre5</version>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -204,7 +209,7 @@
                 <extraClasspath>${basedir}/src/test/resources/</extraClasspath>
               </webAppConfig>
               <connectors>
-                <!--connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector"-->
+                <!--connector implementation="org.surfnet.oaaas.jetty.SelectChannelConnectorHttps"-->
                 <connector implementation="org.surfnet.oaaas.jetty.SelectChannelConnectorHttps">
                   <port>${servlet.port}</port>
                   <maxIdleTime>60000</maxIdleTime>
@@ -258,10 +263,8 @@
 
   </profiles>
 
-
   <build>
     <plugins>
-
       <!--
       Specific jetty-maven-plugin configuration for running Jetty during development.
       None of its goals are run in a normal build lifecycle.
@@ -312,11 +315,17 @@
             <extraClasspath>${basedir}/src/test/resources/</extraClasspath>
           </webAppConfig>
           <connectors>
-            <!--connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector"-->
+            <!--connector implementation="org.surfnet.oaaas.jetty.SelectChannelConnectorHttps"-->
             <connector implementation="org.surfnet.oaaas.jetty.SelectChannelConnectorHttps">
               <port>${servlet.port}</port>
               <host>0.0.0.0</host>
-            </connector>
+	    </connector>
+	    <connector implementation="org.eclipse.jetty.server.ssl.SslSocketConnector">
+		<port>8443</port>
+		<keystore>${project.basedir}/src/main/config/jetty-ssl.keystore</keystore>
+		<password>jetty8</password>
+		<keyPassword>jetty8</keyPassword>
+	    </connector>
           </connectors>
           <reload>manual</reload>
           <stopKey>stopauthserver</stopKey>
@@ -325,6 +334,36 @@
           <contextXml>${basedir}/src/test/resources/jetty-context.xml</contextXml>
         </configuration>
       </plugin>
+      <plugin>
+           <groupId>org.codehaus.mojo</groupId>
+           <artifactId>keytool-maven-plugin</artifactId>
+           <version>1.5</version>
+           <executions>
+             <execution>
+                <phase>generate-resources</phase>
+                <id>clean</id>
+                <goals>
+		   <goal>clean</goal>
+		</goals>
+	     </execution>
+	     <execution>
+                <phase>generate-resources</phase>
+                <id>generateKeyPair</id>
+                <goals>
+                   <goal>generateKeyPair</goal>
+                </goals>
+	     </execution>
+           </executions>
+           <configuration>
+              <keystore>${project.basedir}/src/main/config/jetty-ssl.keystore</keystore>
+	      <dname>cn=localhost</dname>
+		<!--Both `keypass` and `storepass` must be at least 6 characters long. -->
+		<keypass>jetty8</keypass>
+		<storepass>jetty8</storepass>
+		<alias>jetty8</alias>
+		<keyalg>RSA</keyalg>
+	    </configuration>
+	</plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Using hints by stackoverflow user limc from:
https://myshittycode.com/2014/06/03/maven-jetty-enabling-ssl-on-jetty-maven-plugin/comment-page-1/#comment-7217

Only the pom.xml file from apis-authorization-server-war was changed, to add **keytool-maven-plugin** and **SSL connector for jetty-maven-plugin**.

With this code, after run
`$/project-folder/mvn jetty:run`

You can access https://localhost:8443 in your browser. A message from broser about the certificate validity is show, you may ignore because is a self-signed certificate.

This patch solves problems with clients using librares (like AppAuth for Android) wich requires the use of https connection for token requests.