### PR TITLE
Client secret should not be required for "password" grant type

### DIFF
--- a/apis-authorization-server/src/main/java/org/surfnet/oaaas/resource/HealthResource.java
+++ b/apis-authorization-server/src/main/java/org/surfnet/oaaas/resource/HealthResource.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.surfnet.oaaas.resource;
+
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Resource for handling simple health checks, enabling the authorization
+ * server to be monitored by external watchers/tools. 
+ *
+ */
+@Named
+@Path("/health")
+@Produces(MediaType.APPLICATION_JSON)
+public class HealthResource {
+	
+  @GET
+  public Response healthCheck() {
+	  return Response.ok("{ \"status\": \"OK\" }").build();
+  }
+}

--- a/apis-authorization-server/src/test/java/org/surfnet/oaaas/auth/OAuth2ValidatorImplTest.java
+++ b/apis-authorization-server/src/test/java/org/surfnet/oaaas/auth/OAuth2ValidatorImplTest.java
@@ -208,4 +208,20 @@ public class OAuth2ValidatorImplTest {
     return request;
   }
 
+  @Test
+  public void testPasswordTokenRequest() {
+    AccessTokenRequest invalidAccessTokenRequest = new AccessTokenRequest();
+    invalidAccessTokenRequest.setGrantType(OAuth2Validator.GRANT_TYPE_PASSWORD);
+    invalidAccessTokenRequest.setClientId(client.getClientId());
+    ValidationResponse invalidResponse = validator.validate(invalidAccessTokenRequest, BasicAuthCredentials.createCredentialsFromHeader(null));
+    assertEquals(ValidationResponse.INVALID_GRANT_PASSWORD, invalidResponse);
+
+    AccessTokenRequest validAccessTokenRequest = new AccessTokenRequest();
+    validAccessTokenRequest.setGrantType(OAuth2Validator.GRANT_TYPE_PASSWORD);
+    validAccessTokenRequest.setClientId(client.getClientId());
+    validAccessTokenRequest.setUsername("username");
+    validAccessTokenRequest.setPassword("password");
+    ValidationResponse validResponse = validator.validate(validAccessTokenRequest, BasicAuthCredentials.createCredentialsFromHeader(null));
+    assertEquals(ValidationResponse.VALID, validResponse);
+  }
 }

--- a/apis-authorization-server/src/test/java/org/surfnet/oaaas/resource/HealthResourceTest.java
+++ b/apis-authorization-server/src/test/java/org/surfnet/oaaas/resource/HealthResourceTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012 SURFnet bv, The Netherlands
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.surfnet.oaaas.resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+public class HealthResourceTest {
+
+  @InjectMocks
+  private HealthResource healthResource;
+  
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testHealthCheck() {
+	Response response = healthResource.healthCheck();
+    assertEquals("{ \"status\": \"OK\" }", response.getEntity());
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+}


### PR DESCRIPTION
Most of the use cases for password grants are highly trusted mobile or desktop apps. These clientes are public, which means that the client secret cannot be protected (an attacker could extract it from binaries).

Since this grant type already exchanges username and password for an access token directly, the authorization server can ignore the `client_secret` param to validate the client. This prevents attackers from obtaining the client secret and exploring it on other grant types (code grant, for example).

Right now, Apis is requiring a `client_secret` to be defined in order to authenticate with the grant type.

This pull request fixes this issue.